### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/feross/express-sitemap-xml.git"
+    "url": "git+https://github.com/feross/express-sitemap-xml.git"
   },
   "scripts": {
     "test": "standard && tape test/**/*.js"


### PR DESCRIPTION
## Summary

- Update `package.json#repository.url` from the unauthenticated `git://` URL to the public HTTPS form.
- Keep the repository metadata pointing at the same upstream repository.

## Validation

- Checked the current npm metadata for `express-sitemap-xml@3.1.0`.
- Parsed `package.json` and asserted `repository.url === "git+https://github.com/feross/express-sitemap-xml.git"`.
- `git diff --check`
- `git ls-remote https://github.com/feross/express-sitemap-xml.git HEAD`
